### PR TITLE
Dev/refactor triangle

### DIFF
--- a/index.css
+++ b/index.css
@@ -47,25 +47,24 @@
   visibility: visible;
 }
 
-.balloon__link:after {
-  content: '';
+.balloon--position-bottom .balloon__triangle {
+  bottom: 0;
+}
+
+.balloon--position-top .balloon__triangle {
+  transform: rotate(180deg);
+  top: 0;
+}
+
+.balloon__triangle {
+  position: absolute;
   display: block;
   width: 0;
   height: 0;
   border-style: solid;
   border-color: transparent transparent  var(--balloon-triangle-background, var(--color-berlin)) transparent;
-  position: absolute;
   left: 50%;
   margin-left: -var(--balloon-triangle-size);
   border-width: 0 var(--balloon-triangle-size) var(--balloon-triangle-size) var(--balloon-triangle-size);
-  z-index: 1;
-}
-
-.balloon--position-bottom .balloon__link:after {
-  bottom: 0;
-}
-
-.balloon--position-top .balloon__link:after {
-  top: 0;
-  transform: rotate(180deg);
+  z-index: 2;
 }

--- a/index.es6
+++ b/index.es6
@@ -1,6 +1,7 @@
 import React from 'react';
 import Button from '@economist/component-link-button';
 import enhanceWithClickOutside from 'react-click-outside';
+import classnames from 'classnames';
 /* eslint-disable no-console */
 export default class Balloon extends React.Component {
 
@@ -47,10 +48,6 @@ export default class Balloon extends React.Component {
   }
 
   calculatePosition() {
-    // Reset position before calculate the new position.
-    this.setState({
-      position: {},
-    });
     const availableWidth = document.body.getBoundingClientRect().width;
     const balloon = this.refs.balloon;
     const balloonContent = this.refs.balloonContent;
@@ -80,7 +77,7 @@ export default class Balloon extends React.Component {
   }
 
   changeVisibility(visibility) {
-    if(!visibility){
+    if (!visibility) {
       visibility = (this.state.visibility === 'not-visible') ? 'visible' : 'not-visible';
     }
     const position = (visibility === 'visible' && this.props.unstyled === false) ? this.calculatePosition() : {};
@@ -88,11 +85,6 @@ export default class Balloon extends React.Component {
       visibility,
       position,
     });
-  }
-
-  hoverHandler(visibility) {
-    clearTimeout(this.timeout);
-    this.timeout = setTimeout(this.changeVisibility, this.showOnHoverDelay, visibility);
   }
 
   render() {
@@ -105,19 +97,23 @@ export default class Balloon extends React.Component {
       ...this.hoverHandlers,
     };
     TriggerLinkNewProps.className = TriggerLinkClassName;
-    const className = (this.props.className) ? ` ${this.props.className}` : ``;
-    const prefix = ` ${this.props.prefix}--`;
-    const shadow = (this.props.shadow) ? ` ${prefix}shadow` : ``;
-    const balloonDefaultClassname = (this.props.unstyled) ? '' : 'balloon ';
-    const balloonContentDefaultClassname = (this.props.unstyled) ? 'content ' : 'balloon-content ';
+    const prefix = `${this.props.prefix}--`;
+    const visibility = `${prefix}${this.state.visibility}`;
+    const shadow = `${prefix}shadow`;
+    const position = `${prefix}position-${this.props.balloonPosition}`;
+    const balloonContentClassname = (this.props.unstyled) ? 'content' : 'balloon-content';
+    const triangleShouldDisplay = this.state.visibility === 'visible' && !this.props.unstyled;
     return (
-      <div ref="balloon" className={`${balloonDefaultClassname}${prefix}position-${this.props.balloonPosition} ${prefix}${this.state.visibility}${className}`}>
+      <div ref="balloon" className={classnames(position, visibility,
+        { balloon: !this.props.unstyled, [this.props.className]: this.props.className }
+      )}>
+        { triangleShouldDisplay && <div className="balloon__triangle" /> }
         <TriggerLink {...TriggerLinkNewProps}
           onClick={this.toggleState.bind(this)}
         />
         <div
           ref="balloonContent"
-          className={`${balloonContentDefaultClassname}${shadow}`}
+          className={classnames(balloonContentClassname, { [shadow]: this.props.shadow } )}
           style={this.state.position}
           {...this.hoverHandlers}
         >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-balloon",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A balloon that can expose content when an click happens",
   "author": "The Economist (http://economist.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -131,8 +131,9 @@
   },
   "dependencies": {
     "@economist/component-grid": "^1.3.0",
-    "@economist/component-palette": "^1.2.0",
     "@economist/component-link-button": "^2.0.0",
+    "@economist/component-palette": "^1.2.0",
+    "classnames": "^2.2.3",
     "react-click-outside": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The tiny triangle used to be a :after element. This would cause the styles applied to the link (e.g., filter) to leak to this element too. Now it has been extracted to an external node.