### PR TITLE
Bug/triangle alignment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,14 +44,13 @@ export default class Balloon extends React.Component {
 
   calculatePosition() {
     const availableWidth = document.body.getBoundingClientRect().width;
-    const balloon = this.refs.balloon;
-    const balloonContent = this.refs.balloonContent;
+    const { balloon, balloonContent } = this.refs;
     const balloonContentWidth = balloonContent.offsetWidth;
-    const halfWidthDivider = 2;
-    const halfBalloonWidth = balloon.offsetWidth / halfWidthDivider;
-    const halfBalloonContentWidth = balloonContentWidth / halfWidthDivider;
-    const centerLeftOffsetBalloon = balloon.offsetLeft + halfBalloonContentWidth;
-    const centerRightOffsetBalloon = availableWidth - (balloon.offsetLeft + balloon.offsetWidth / halfWidthDivider);
+    const TWO = 2;
+    const halfBalloonWidth = balloon.offsetWidth / TWO;
+    const halfBalloonContentWidth = balloonContentWidth / TWO;
+    const centerLeftOffsetBalloon = balloon.offsetLeft + halfBalloonWidth;
+    const centerRightOffsetBalloon = availableWidth - (balloon.offsetLeft + balloon.offsetWidth / TWO);
     const position = {};
     if (centerLeftOffsetBalloon < halfBalloonContentWidth) {
       // Put Ballon on the left or will be partially not visible.

--- a/src/index.js
+++ b/src/index.js
@@ -117,8 +117,10 @@ export default class Balloon extends React.Component {
     }
     return (
       <div ref="balloon" className={rootClassNames}>
-        {triangleElement}
-        <TriggerLink {...triggerLinkNewProps}/>
+        <span style={{ position: 'relative' }}>
+          {triangleElement}
+          <TriggerLink {...triggerLinkNewProps}/>
+        </span>
         <div
           ref="balloonContent"
           className={contentClassNames}

--- a/src/index.js
+++ b/src/index.js
@@ -42,9 +42,7 @@ export default class Balloon extends React.Component {
     });
   }
 
-  calculatePosition() {
-    const availableWidth = document.body.getBoundingClientRect().width;
-    const { balloon, balloonContent } = this.refs;
+  calculatePosition(availableWidth, balloon, balloonContent) {
     const balloonContentWidth = balloonContent.offsetWidth;
     const TWO = 2;
     const halfBalloonWidth = balloon.offsetWidth / TWO;
@@ -77,7 +75,13 @@ export default class Balloon extends React.Component {
     if (!visibility) {
       visibility = (this.state.visibility === 'not-visible') ? 'visible' : 'not-visible';
     }
-    const position = (visibility === 'visible' && this.props.unstyled === false) ? this.calculatePosition() : {};
+    const position = (visibility === 'visible' && this.props.unstyled === false) ?
+      this.calculatePosition(
+        document.body.getBoundingClientRect().width,
+        this.refs.balloon,
+        this.refs.balloonContent
+      ) :
+      {};
     this.setState({
       visibility,
       position,

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,10 @@
 import Balloon from '../src';
 import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
 import chai from 'chai';
 chai.should();
+
 describe('Balloon', () => {
   it('is compatible with React.Component', () => {
     Balloon.should.be.a('function')
@@ -24,7 +27,53 @@ describe('Balloon', () => {
       balloon.props.children.type.should.equal('div');
       balloon.props.children.props.children.should.equal('Content element');
     });
-
   });
+
+  describe('Positioning', () => {
+    let balloonElement = null;
+
+    before(() => {
+      const triggerElement = (<a>Trigger link</a>);
+      balloonElement = TestUtils.renderIntoDocument(
+        <Balloon trigger={triggerElement}>
+          <div>Content element</div>
+        </Balloon>
+      );
+    });
+
+    it('should return { left: 0 }', () => {
+      const availableWidth = 400;
+      const balloonDOM = { offsetWidth: 207, offsetLeft: 20 };
+      const balloonContentDOM = { offsetWidth: 300 };
+
+      balloonElement.
+        __wrappedComponent
+        .calculatePosition(availableWidth, balloonDOM, balloonContentDOM)
+        .should.deep.equal({ left: 0 });
+    });
+
+    it('should return { right: 0 }', () => {
+      const availableWidth = 400;
+      const balloonDOM = { offsetWidth: 251, offsetLeft: 129 };
+      const balloonContentDOM = { offsetWidth: 300 };
+
+      balloonElement.
+        __wrappedComponent
+        .calculatePosition(availableWidth, balloonDOM, balloonContentDOM)
+        .should.deep.equal({ right: 0 });
+    });
+
+    it('should return { left: -24 }', () => {
+      const availableWidth = 863;
+      const balloonDOM = { offsetWidth: 251, offsetLeft: 359 };
+      const balloonContentDOM = { offsetWidth: 300 };
+
+      balloonElement.
+        __wrappedComponent
+        .calculatePosition(availableWidth, balloonDOM, balloonContentDOM)
+        .should.deep.equal({ left: -24 });
+    });
+  });
+
 
 });


### PR DESCRIPTION
Having refactored the triangle to an independent DOM node rather than an `:after` pseudo element, caused the triangle to be misaligned in case of a `position:relative` set somewhere else than the triangle parent element.

