### PR TITLE
feat: Add way to control the close/open functionality via API

### DIFF
--- a/src/example.js
+++ b/src/example.js
@@ -21,7 +21,7 @@ const exampleThreeTrigger = (
 export class ExternalControlledBalloon extends React.Component {
   static propTypes = {
     open: PropTypes.bool,
-  }
+  };
   constructor(props) {
     super();
     this.state = {
@@ -42,7 +42,7 @@ export class ExternalControlledBalloon extends React.Component {
         <a href="#" onClick={this.handleHideBalloon}>
           External controller link
         </a>
-        <Balloon unstyled balloonPosition="top" prefix="external"
+        <Balloon unstyled balloonPosition="top" prefix="custom-classname"
           visible={this.state.open}
         >
           <div>Opened by default</div>

--- a/src/example.js
+++ b/src/example.js
@@ -17,37 +17,55 @@ const exampleThreeTrigger = (
     Unstyled
   </Button>
 );
+export class ExternalControlledBalloon extends React.Component {
+  constructor(props) {
+    super();
+    this.state = {
+      open: props.open,
+    };
+    this.handleHideBalloon = this.handleHideBalloon.bind(this);
+  }
+
+  handleHideBalloon() {
+    this.setState({
+      open: !this.state.open,
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <a href="#" onClick={this.handleHideBalloon}>
+          External controller link
+        </a>
+        <Balloon unstyled balloonPosition="top" prefix="external" visible={this.state.open}>
+          <div>Opened by default</div>
+        </Balloon>
+      </div>
+    );
+  }
+}
 export default (
   <div>
-    <div className="balloon-example no-mobile">
-    </div>
+    <div className="balloon-example no-mobile" />
     <div className="balloon-example">
       <Balloon trigger={exampleOneTrigger}>
-        <div>
-          The position of the balloon, as its width, can be styled by the context.
-        </div>
+        <div>The position of the balloon, as its width, can be styled by the context.</div>
       </Balloon>
     </div>
     <div className="balloon-example right">
       <Balloon balloonPosition="top" showOnHover trigger={exampleTwoTrigger}>
-        <div>
-          The position of the balloon, as its width, can be styled by the context.
-        </div>
+        <div>The position of the balloon, as its width, can be styled by the context.</div>
       </Balloon>
     </div>
     <div className="balloon-example right">
-      <Balloon
-        unstyled
-        balloonPosition="top"
-        prefix="custom-classname"
-        trigger={exampleThreeTrigger}
-      >
-        <div>
-          The position of the balloon, as its width, can be styled by the context.
-        </div>
+      <Balloon unstyled balloonPosition="top" prefix="custom-classname" trigger={exampleThreeTrigger}>
+        <div>The position of the balloon, as its width, can be styled by the context.</div>
       </Balloon>
     </div>
-    <div className="balloon-example no-mobile">
+    <div className="balloon-example right">
+      <ExternalControlledBalloon open />
     </div>
+    <div className="balloon-example no-mobile" />
   </div>
 );

--- a/src/example.js
+++ b/src/example.js
@@ -1,6 +1,7 @@
 import Balloon from './';
 import Button from '@economist/component-link-button';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const exampleOneTrigger = (
   <a href="https://www.economist.com/user/login" className="balloon-link">
@@ -18,6 +19,9 @@ const exampleThreeTrigger = (
   </Button>
 );
 export class ExternalControlledBalloon extends React.Component {
+  static propTypes = {
+    open: PropTypes.bool,
+  }
   constructor(props) {
     super();
     this.state = {
@@ -38,7 +42,9 @@ export class ExternalControlledBalloon extends React.Component {
         <a href="#" onClick={this.handleHideBalloon}>
           External controller link
         </a>
-        <Balloon unstyled balloonPosition="top" prefix="external" visible={this.state.open}>
+        <Balloon unstyled balloonPosition="top" prefix="external"
+          visible={this.state.open}
+        >
           <div>Opened by default</div>
         </Balloon>
       </div>
@@ -59,7 +65,9 @@ export default (
       </Balloon>
     </div>
     <div className="balloon-example right">
-      <Balloon unstyled balloonPosition="top" prefix="custom-classname" trigger={exampleThreeTrigger}>
+      <Balloon unstyled balloonPosition="top" prefix="custom-classname"
+        trigger={exampleThreeTrigger}
+      >
         <div>The position of the balloon, as its width, can be styled by the context.</div>
       </Balloon>
     </div>

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import enhanceWithClickOutside from 'react-click-outside';
 /* eslint-disable no-console */
 class Balloon extends React.Component {
-
   static propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
@@ -15,8 +14,9 @@ class Balloon extends React.Component {
     showOnHover: PropTypes.bool,
     showOnHoverDelay: PropTypes.number,
     dynamicPositioning: PropTypes.bool,
-    trigger: PropTypes.element.isRequired,
-  }
+    trigger: PropTypes.element,
+    visible: PropTypes.bool,
+  };
 
   static defaultProps = {
     dynamicPositioning: true,
@@ -25,18 +25,33 @@ class Balloon extends React.Component {
     unstyled: false,
     prefix: 'balloon',
     showOnHoverDelay: 100,
-  }
+    visible: false,
+  };
 
   constructor(props) {
     super(props);
     this.state = {
-      visibility: 'not-visible',
+      visibility: this.props.visible ? 'visible' : 'not-visible',
     };
-    this.hoverHandlers = (this.props.showOnHover) ? {
-      onMouseOver: this.changeVisibility.bind(this, 'visible'),
-      onMouseOut: this.changeVisibility.bind(this, 'not-visible'),
-    } : {};
+    this.hoverHandlers = this.props.showOnHover
+      ? {
+        onMouseOver: this.changeVisibility.bind(this, 'visible'),
+        onMouseOut: this.changeVisibility.bind(this, 'not-visible'),
+      }
+      : {};
     this.toggleState = this.toggleState.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.visible !== this.props.visible) {
+      this.setVisibilityState(nextProps.visible);
+    }
+  }
+
+  setVisibilityState(visibility) {
+    this.setState({
+      visibility: visibility ? 'visible' : 'not-visible',
+    });
   }
 
   handleClickOutside() {
@@ -77,37 +92,45 @@ class Balloon extends React.Component {
   changeVisibility(visibility) {
     const { dynamicPositioning, unstyled } = this.props;
     if (!visibility) {
-      visibility = (this.state.visibility === 'not-visible') ? 'visible' : 'not-visible';
+      visibility = this.state.visibility === 'not-visible' ? 'visible' : 'not-visible';
     }
-    const position = (visibility === 'visible' && unstyled === false && dynamicPositioning) ?
-      this.calculatePosition(
-        document.body.getBoundingClientRect().width,
-        this.refs.balloon,
-        this.refs.balloonContent
-      ) :
-      {};
-    this.setState({
-      visibility,
-      position,
-    }, () => {
-      if (visibility === 'visible') {
-        this.refs.balloonContent.focus();
+    const position =
+      visibility === 'visible' && unstyled === false && dynamicPositioning
+        ? this.calculatePosition(
+            document.body.getBoundingClientRect().width,
+            this.refs.balloon,
+            this.refs.balloonContent
+          )
+        : {};
+    this.setState(
+      {
+        visibility,
+        position,
+      },
+      () => {
+        if (visibility === 'visible') {
+          this.refs.balloonContent.focus();
+        }
       }
-    });
+    );
   }
 
   render() {
     const { trigger, className } = this.props;
-    const { type: TriggerLink, className: triggerClassName, props: triggerProps } = trigger;
-    /* eslint-disable undefined see https://github.com/eslint/espree/issues/116 */
-    const triggerLinkNewProps = {
-      className: `${ this.props.prefix }__link${ triggerClassName ? ` ${ triggerClassName }` : '' }`,
-      onClick: this.toggleState,
-      ...triggerProps,
-      ...this.hoverHandlers,
-    };
+    let triggerLink = null;
+    if (trigger) {
+      const { type: TriggerLink, className: triggerClassName, props: triggerProps } = trigger;
+      /* eslint-disable undefined see https://github.com/eslint/espree/issues/116 */
+      const triggerLinkNewProps = {
+        className: `${ this.props.prefix }__link${ triggerClassName ? ` ${ triggerClassName }` : '' }`,
+        onClick: this.toggleState,
+        ...triggerProps,
+        ...this.hoverHandlers,
+      };
+      triggerLink = <TriggerLink {...triggerLinkNewProps} />;
+    }
     const prefix = `${ this.props.prefix }--`;
-    const balloonContentClassname = (this.props.unstyled) ? 'content' : 'balloon-content';
+    const balloonContentClassname = this.props.unstyled ? 'content' : 'balloon-content';
     const triangleShouldDisplay = this.state.visibility === 'visible' && !this.props.unstyled;
     const rootClassNames = classNames(
       `${ prefix }position-${ this.props.balloonPosition }`,
@@ -117,21 +140,18 @@ class Balloon extends React.Component {
         balloon: !this.props.unstyled,
       }
     );
-    const contentClassNames = classNames(
-      balloonContentClassname,
-      {
-        [`${ prefix }shadow`]: this.props.shadow,
-      }
-    );
+    const contentClassNames = classNames(balloonContentClassname, {
+      [`${ prefix }shadow`]: this.props.shadow,
+    });
     let triangleElement = null;
     if (triangleShouldDisplay) {
-      triangleElement = (<div className="balloon__triangle" style={{ pointerEvents: 'none' }} />);
+      triangleElement = <div className="balloon__triangle" style={{ pointerEvents: 'none' }} />;
     }
     return (
       <div ref="balloon" className={rootClassNames}>
         <span style={{ position: 'relative' }}>
           {triangleElement}
-          <TriggerLink {...triggerLinkNewProps} />
+          {triggerLink}
         </span>
         <div
           ref="balloonContent"

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ class Balloon extends React.Component {
     dynamicPositioning: PropTypes.bool,
     trigger: PropTypes.element,
     visible: PropTypes.bool,
+    open: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -33,12 +34,11 @@ class Balloon extends React.Component {
     this.state = {
       visibility: this.props.visible ? 'visible' : 'not-visible',
     };
-    this.hoverHandlers = this.props.showOnHover
-      ? {
+    this.hoverHandlers = this.props.showOnHover ?
+      {
         onMouseOver: this.changeVisibility.bind(this, 'visible'),
         onMouseOut: this.changeVisibility.bind(this, 'not-visible'),
-      }
-      : {};
+      } : {};
     this.toggleState = this.toggleState.bind(this);
   }
 
@@ -95,13 +95,12 @@ class Balloon extends React.Component {
       visibility = this.state.visibility === 'not-visible' ? 'visible' : 'not-visible';
     }
     const position =
-      visibility === 'visible' && unstyled === false && dynamicPositioning
-        ? this.calculatePosition(
+      visibility === 'visible' && unstyled === false && dynamicPositioning ?
+        this.calculatePosition(
             document.body.getBoundingClientRect().width,
             this.refs.balloon,
             this.refs.balloonContent
-          )
-        : {};
+          ) : {};
     this.setState(
       {
         visibility,

--- a/test/index.js
+++ b/test/index.js
@@ -54,9 +54,9 @@ describe('Balloon', () => {
       const trigger = externalControledBalloon.find('a');
       const balloon = externalControledBalloon.find(Balloon);
       trigger.simulate('click');
-      balloon.should.have.className('external--visible');
+      balloon.should.have.className('custom-classname--visible');
       trigger.simulate('click');
-      balloon.should.have.className('external--not-visible');
+      balloon.should.have.className('custom-classname--not-visible');
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ import Enzyme from 'enzyme';
 import chaiEnzyme from 'chai-enzyme';
 import { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { ExternalControlledBalloon } from '../src/example';
 
 Enzyme.configure({ adapter: new Adapter() });
 chai.use(chaiEnzyme()).should();
@@ -30,8 +31,7 @@ const mountBalloonWithChildren = mountBalloon(<div>Content element</div>);
 const mountBalloonWithProps = mountBalloonWithChildren(requiredProps);
 describe('Balloon', () => {
   it('is compatible with React.Component', () => {
-    Balloon.should.be.a('function')
-      .and.respondTo('render');
+    Balloon.should.be.a('function').and.respondTo('render');
   });
 
   it('renders a React element', () => {
@@ -39,13 +39,24 @@ describe('Balloon', () => {
   });
 
   describe('Rendering', () => {
-
     it('it return the trigger before the content element', () => {
       const balloon = mountBalloonWithProps();
       balloon.should.have.exactly(1).descendants('a');
       balloon.find('a').should.have.text('Trigger link');
       balloon.childAt(0).should.have.tagName('div');
       balloon.find('.balloon-content').should.have.text('Content element');
+    });
+  });
+
+  describe('Can be open and closed via API', () => {
+    it('shows if visible prop is true', () => {
+      const externalControledBalloon = mount(<ExternalControlledBalloon />);
+      const trigger = externalControledBalloon.find('a');
+      const balloon = externalControledBalloon.find(Balloon);
+      trigger.simulate('click');
+      balloon.should.have.className('external--visible');
+      trigger.simulate('click');
+      balloon.should.have.className('external--not-visible');
     });
   });
 
@@ -87,29 +98,21 @@ describe('Balloon', () => {
       const availableWidth = 400;
       const balloonDOM = { offsetWidth: 207, offsetLeft: 20 };
       const balloonContentDOM = { offsetWidth: 300 };
-      balloonElement
-        .calculatePosition(availableWidth, balloonDOM, balloonContentDOM)
-        .should.deep.equal({ left: 0 });
+      balloonElement.calculatePosition(availableWidth, balloonDOM, balloonContentDOM).should.deep.equal({ left: 0 });
     });
 
     it('should return { right: 0 }', () => {
       const availableWidth = 400;
       const balloonDOM = { offsetWidth: 251, offsetLeft: 129 };
       const balloonContentDOM = { offsetWidth: 300 };
-      balloonElement
-        .calculatePosition(availableWidth, balloonDOM, balloonContentDOM)
-        .should.deep.equal({ right: 0 });
+      balloonElement.calculatePosition(availableWidth, balloonDOM, balloonContentDOM).should.deep.equal({ right: 0 });
     });
 
     it('should return { left: -24 }', () => {
       const availableWidth = 863;
       const balloonDOM = { offsetWidth: 251, offsetLeft: 359 };
       const balloonContentDOM = { offsetWidth: 300 };
-      balloonElement
-        .calculatePosition(availableWidth, balloonDOM, balloonContentDOM)
-        .should.deep.equal({ left: -24 });
+      balloonElement.calculatePosition(availableWidth, balloonDOM, balloonContentDOM).should.deep.equal({ left: -24 });
     });
   });
-
-
 });


### PR DESCRIPTION
In this PR https://github.com/EconomistDigitalSolutions/fe-blogs/pull/1647 I need to control the open/close functionality of the ballon with a state from redux. So here I'm adding a prop that makes the component controllable from the outside.

Prettify add some additional formatting on top of the PR.