### PR TITLE
fix(travix): use stages instead of deprecated travis-after-all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,20 @@ cache:
 node_js:
   - '6'
   - stable
-after_success: >-
-  travis-after-all && npm run semantic-release && npm run pages -- --repo
-  https://${GH_TOKEN}@github.com/economist-components/component-balloon.git
+
+stages:
+  - name: test
+  - name: release
+    if: >-
+      (branch = master) AND
+      (repo = economist-components/component-balloon) AND
+      (env(NPM_TOKEN) IS present) AND
+      (NOT (type IN (push, pull_request)))
+
+jobs:
+  include:
+    - stage: release
+      node_js: stable
+      script: >-
+        npm run semantic-release && npm run pages -- --repo
+        https://${GH_TOKEN}@github.com/economist-components/component-balloon.git

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     "semantic-release": "^4.3.5",
     "stylelint": "^6.3.3",
     "stylelint-config-strict": "^5.0.0",
-    "travis-after-all": "^1.4.4",
     "validate-commit-msg": "^2.6.1",
     "watchify": "^3.7.0"
   }


### PR DESCRIPTION
[`travis-after-all` has been deprecated](https://github.com/alrra/travis-after-all) and the deployment could not happen, because each test build for waiting for the other one to finish. The new, better way to manage cases like this is with the use of [stages on Travis](https://blog.travis-ci.com/2017-05-11-introducing-build-stages).
